### PR TITLE
More market refactoring and clean up

### DIFF
--- a/src/_layouts/slab.py
+++ b/src/_layouts/slab.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Iterable, List, NamedTuple, Optional
+from typing import Iterable, List, NamedTuple, Optional, Sequence
 
 from construct import Switch  # type: ignore
 from construct import Bytes, Int8ul, Int32ul, Int64ul, Padding
@@ -150,7 +150,7 @@ class Slab:
         self._nodes = nodes
 
     @staticmethod
-    def decode(buffer: bytes) -> Slab:
+    def from_bytes(buffer: Sequence[int]) -> Slab:
         slab_layout = SLAB_LAYOUT.parse(buffer)
         header = slab_layout.header
         nodes = slab_layout.nodes

--- a/src/client.py
+++ b/src/client.py
@@ -1,6 +1,0 @@
-from solana.rpc.api import Client
-
-
-def market_client(endpoint: str) -> Client:
-    """RPC client to interact with the Serum Dex."""
-    return Client(endpoint)

--- a/src/connection.py
+++ b/src/connection.py
@@ -1,0 +1,6 @@
+from solana.rpc.api import Client
+
+
+def conn(endpoint: str) -> Client:
+    """RPC client connection to interact with the Serum Dex."""
+    return Client(endpoint)

--- a/src/market/__init__.py
+++ b/src/market/__init__.py
@@ -1,2 +1,2 @@
-from .market import Market, Order, OrderBook, OrderInfo  # noqa: F401
-from .state import AccountFlags, MarketState  # noqa: F401
+from .market import Market, OrderBook  # noqa: F401
+from .state import MarketState as State  # noqa: F401

--- a/src/market/__init__.py
+++ b/src/market/__init__.py
@@ -1,2 +1,2 @@
-from .market import Market, Order, OrderBook, OrderInfo  # noqa
-from .state import AccountFlags, MarketState  # noqa
+from .market import Market, Order, OrderBook, OrderInfo  # noqa: F401
+from .state import AccountFlags, MarketState  # noqa: F401

--- a/src/market/__init__.py
+++ b/src/market/__init__.py
@@ -1,2 +1,2 @@
-from .market import MARKET_LAYOUT, Market, Order, OrderBook, OrderInfo  # noqa
+from .market import Market, Order, OrderBook, OrderInfo  # noqa
 from .state import AccountFlags, MarketState  # noqa

--- a/src/market/market.py
+++ b/src/market/market.py
@@ -277,14 +277,14 @@ def get_price_from_key(key: int) -> int:
 class OrderBook:
     """Represents an order book."""
 
-    _market: MarketState
+    _market_state: MarketState
     _is_bids: bool
     _slab: Slab
 
     def __init__(self, market_state: MarketState, account_flags: t.AccountFlags, slab: Slab) -> None:
         if not account_flags.initialized or not account_flags.bids ^ account_flags.asks:
             raise Exception("Invalid order book, either not initialized or neither of bids or asks")
-        self._market = market_state
+        self._market_state = market_state
         self._is_bids = account_flags.bids
         self._slab = slab
 
@@ -312,8 +312,8 @@ class OrderBook:
                 levels.append([price, node.quantity])
         return [
             t.OrderInfo(
-                price=self._market.price_lots_to_number(price_lots),
-                size=self._market.base_size_lots_to_number(size_lots),
+                price=self._market_state.price_lots_to_number(price_lots),
+                size=self._market_state.base_size_lots_to_number(size_lots),
                 price_lots=price_lots,
                 size_lots=size_lots,
             )
@@ -335,9 +335,9 @@ class OrderBook:
                 open_order_address=open_orders_address,
                 fee_tier=node.fee_tier,
                 order_info=t.OrderInfo(
-                    price=self._market.price_lots_to_number(price),
+                    price=self._market_state.price_lots_to_number(price),
                     price_lots=price,
-                    size=self._market.base_size_lots_to_number(node.quantity),
+                    size=self._market_state.base_size_lots_to_number(node.quantity),
                     size_lots=node.quantity,
                 ),
                 side=Side.Buy if self._is_bids else Side.Sell,

--- a/src/market/market.py
+++ b/src/market/market.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterable, List, NamedTuple
+from typing import Any, Iterable, List
 
 from solana.account import Account
 from solana.publickey import PublicKey
@@ -21,6 +21,7 @@ from ..open_orders_account import OpenOrdersAccount, make_create_account_instruc
 from ..queue_ import decode_event_queue, decode_request_queue
 from ..utils import load_bytes_data
 from .state import MarketState
+from .types import FilledOrder, Order, OrderInfo
 
 
 # pylint: disable=too-many-public-methods
@@ -258,31 +259,6 @@ class Market:
         if not signature:
             raise Exception("Transaction not sent successfully.")
         return str(signature)
-
-
-class FilledOrder(NamedTuple):
-    order_id: int
-    side: Side
-    price: float
-    size: float
-    fee_cost: int
-
-
-class OrderInfo(NamedTuple):
-    price: float
-    size: float
-    price_lots: int
-    size_lots: int
-
-
-class Order(NamedTuple):
-    order_id: int
-    client_id: int
-    open_order_address: PublicKey
-    open_order_slot: int
-    fee_tier: int
-    order_info: OrderInfo
-    side: Side
 
 
 # The key is constructed as the (price << 64) + (seq_no if ask_order else !seq_no)

--- a/src/market/market.py
+++ b/src/market/market.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable, List
+from typing import Iterable, List, Sequence
 
 from solana.account import Account
 from solana.publickey import PublicKey
@@ -72,12 +72,12 @@ class Market:
     def load_bids(self) -> OrderBook:
         """Load the bid order book"""
         bytes_data = load_bytes_data(self.state.bids(), self._conn)
-        return OrderBook.decode(self.state, bytes_data)
+        return OrderBook.from_bytes(self.state, bytes_data)
 
     def load_asks(self) -> OrderBook:
         """Load the Ask order book."""
         bytes_data = load_bytes_data(self.state.asks(), self._conn)
-        return OrderBook.decode(self.state, bytes_data)
+        return OrderBook.from_bytes(self.state, bytes_data)
 
     def load_orders_for_owner(self) -> List[types.Order]:
         raise NotImplementedError("load_orders_for_owner not implemented")
@@ -289,7 +289,7 @@ class OrderBook:
         self._slab = slab
 
     @staticmethod
-    def decode(market_state: MarketState, buffer: bytes) -> OrderBook:
+    def from_bytes(market_state: MarketState, buffer: Sequence[int]) -> OrderBook:
         """Decode the given buffer into an order book."""
         # This is a bit hacky at the moment. The first 5 bytes are padding, the
         # total length is 8 bytes which is 5 + 8 = 13 bytes.

--- a/src/market/market.py
+++ b/src/market/market.py
@@ -294,7 +294,7 @@ class OrderBook:
         # This is a bit hacky at the moment. The first 5 bytes are padding, the
         # total length is 8 bytes which is 5 + 8 = 13 bytes.
         account_flags = types.AccountFlags.from_bytes(buffer[5:13])
-        slab = Slab.decode(buffer[13:])
+        slab = Slab.from_bytes(buffer[13:])
         return OrderBook(market_state, account_flags, slab)
 
     def get_l2(self, depth: int) -> List[types.OrderInfo]:

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 from construct import Container, Struct  # type: ignore
 from solana.publickey import PublicKey

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import math
 from typing import Any, NamedTuple
 
+from construct import Container, Struct  # type: ignore
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 
-from src._layouts.market import MINT_LAYOUT
-from src.utils import load_bytes_data
+from src.utils import get_mint_decimals, load_bytes_data
+
+from .._layouts.market import MARKET_LAYOUT
 
 
 class AccountFlags(NamedTuple):
@@ -33,37 +35,98 @@ class AccountFlags(NamedTuple):
         )
 
 
-class MarketState(NamedTuple):
-    account_flags: AccountFlags = AccountFlags()
-    own_address: PublicKey = PublicKey(0)
-    vault_signer_nonce: int = 0
-    base_mint: PublicKey = PublicKey(0)
-    quote_mint: PublicKey = PublicKey(0)
-    base_vault: PublicKey = PublicKey(0)
-    base_deposits_total: int = 0
-    base_fees_accrued: int = 0
-    quote_vault: PublicKey = PublicKey(0)
-    quote_deposits_total: int = 0
-    quote_fees_accrued: int = 0
-    quote_dust_threshold: int = 0
-    request_queue: PublicKey = PublicKey(0)
-    event_queue: PublicKey = PublicKey(0)
-    bids: PublicKey = PublicKey(0)
-    asks: PublicKey = PublicKey(0)
-    base_lot_size: int = 1
-    quote_lot_size: int = 1
-    fee_rate_bps: int = 0
-    base_spl_token_decimals: int = 0
-    quote_spl_token_decimals: int = 0
-    program_id: PublicKey = PublicKey(0)
-    skip_preflight: bool = False
-    confirmations: int = 0
+class MarketState:  # pylint: disable=too-many-public-methods
+    def __init__(
+        self, parsed_market: Container, program_id: PublicKey, base_mint_decimals: int, quote_mint_decimals: int
+    ) -> None:
+        self._decoded = parsed_market
+        self._program_id = program_id
+        self._base_mint_decimals = base_mint_decimals
+        self._quote_mint_decimals = quote_mint_decimals
+
+    @staticmethod
+    def LAYOUT() -> Struct:  # pylint: disable=invalid-name
+        """Construct layout of the market state."""
+        return MARKET_LAYOUT
+
+    @staticmethod
+    def load(conn: Client, market_address: PublicKey, program_id: PublicKey) -> MarketState:
+        bytes_data = load_bytes_data(market_address, conn)
+        parsed_market = MARKET_LAYOUT.parse(bytes_data)
+        # TODO: add ownAddress check!
+
+        if not parsed_market.account_flags.initialized or not parsed_market.account_flags.market:
+            raise Exception("Invalid market")
+
+        base_mint_decimals = get_mint_decimals(conn, PublicKey(parsed_market.base_mint))
+        quote_mint_decimals = get_mint_decimals(conn, PublicKey(parsed_market.quote_mint))
+        return MarketState(parsed_market, program_id, base_mint_decimals, quote_mint_decimals)
+
+    def program_id(self) -> PublicKey:
+        return self._program_id
+
+    def public_key(self) -> PublicKey:
+        return PublicKey(self._decoded.own_address)
+
+    def account_flags(self) -> AccountFlags:
+        return AccountFlags.init(self._decoded.account_flags)
+
+    def asks(self) -> PublicKey:
+        return PublicKey(self._decoded.asks)
+
+    def bids(self) -> PublicKey:
+        return PublicKey(self._decoded.bids)
+
+    def fee_rate_bps(self) -> int:
+        return self._decoded.fee_rate_bps
+
+    def event_queue(self) -> PublicKey:
+        return PublicKey(self._decoded.event_queue)
+
+    def request_queue(self) -> PublicKey:
+        return PublicKey(self._decoded.request_queue)
+
+    def vault_signer_nonce(self) -> PublicKey:
+        return self._decoded.vault_signer_nonce
+
+    def base_mint(self) -> PublicKey:
+        return self._decoded.base_mint
+
+    def quote_mint(self) -> PublicKey:
+        return self._decoded.quote_mint
+
+    def base_vault(self) -> PublicKey:
+        return self._decoded.base_vault
+
+    def quote_vault(self) -> PublicKey:
+        return self._decoded.quote_vault
+
+    def base_deposits_total(self) -> int:
+        return self._decoded.base_deposits_total
+
+    def quote_deposits_total(self) -> int:
+        return self._decoded.quote_deposits_total
+
+    def base_fees_accrued(self) -> int:
+        return self._decoded.base_fees_accrued
+
+    def quote_fees_accrued(self) -> int:
+        return self._decoded.quote_fees_accrued
+
+    def quote_dust_threshold(self) -> int:
+        return self._decoded.quote_dust_threshold
+
+    def base_spl_token_decimals(self) -> int:
+        return self._base_mint_decimals
+
+    def quote_spl_token_decimals(self) -> int:
+        return self._quote_mint_decimals
 
     def base_spl_token_multiplier(self) -> int:
-        return 10 ** self.base_spl_token_decimals
+        return 10 ** self._base_mint_decimals
 
     def quote_spl_token_multiplier(self) -> int:
-        return 10 ** self.quote_spl_token_decimals
+        return 10 ** self._quote_mint_decimals
 
     def base_spl_size_to_number(self, size: int) -> float:
         return size / self.base_spl_token_multiplier()
@@ -71,64 +134,27 @@ class MarketState(NamedTuple):
     def quote_spl_size_to_number(self, size: int) -> float:
         return size / self.quote_spl_token_multiplier()
 
+    def base_lot_size(self) -> int:
+        return self._decoded.base_lot_size
+
+    def quote_lot_size(self) -> int:
+        return self._decoded.quote_lot_size
+
     def price_lots_to_number(self, price: int) -> float:
-        return float(price * self.quote_lot_size * self.base_spl_token_multiplier()) / (
-            self.base_lot_size * self.quote_spl_token_multiplier()
+        return float(price * self.quote_lot_size() * self.base_spl_token_multiplier()) / (
+            self.base_lot_size() * self.quote_spl_token_multiplier()
         )
 
     def price_number_to_lots(self, price: float) -> int:
         return int(
             round(
-                (price * 10 ** self.quote_spl_token_multiplier() * self.base_lot_size)
-                / (10 ** self.base_spl_token_multiplier() * self.quote_lot_size)
+                (price * 10 ** self.quote_spl_token_multiplier() * self.base_lot_size())
+                / (10 ** self.base_spl_token_multiplier() * self.quote_lot_size())
             )
         )
 
     def base_size_lots_to_number(self, size: int) -> float:
-        return float(size * self.base_lot_size) / self.base_spl_token_multiplier()
+        return float(size * self.base_lot_size()) / self.base_spl_token_multiplier()
 
     def base_size_number_to_lots(self, size: float) -> int:
-        return int(math.floor(size * 10 ** self.base_spl_token_decimals) / self.base_lot_size)
-
-    # The first argument is construct parsed account flags.
-    @staticmethod
-    def load(con: Any, program_id: PublicKey, client: Client) -> MarketState:
-        # TODO: add ownAddress check!
-        if not con.account_flags.initialized or not con.account_flags.market:
-            raise Exception("Invalid market")
-
-        base_mint_decimals = get_mint_decimals(client, PublicKey(con.base_mint))
-        quote_mint_decimals = get_mint_decimals(client, PublicKey(con.quote_mint))
-
-        return MarketState(
-            account_flags=AccountFlags.init(con.account_flags),
-            own_address=PublicKey(con.own_address),
-            vault_signer_nonce=con.vault_signer_nonce,
-            base_mint=PublicKey(con.base_mint),
-            quote_mint=PublicKey(con.quote_mint),
-            base_vault=PublicKey(con.base_vault),
-            base_deposits_total=con.base_deposits_total,
-            base_fees_accrued=con.base_fees_accrued,
-            quote_vault=PublicKey(con.quote_vault),
-            quote_deposits_total=con.quote_deposits_total,
-            quote_fees_accrued=con.quote_fees_accrued,
-            quote_dust_threshold=con.quote_dust_threshold,
-            request_queue=PublicKey(con.request_queue),
-            event_queue=PublicKey(con.event_queue),
-            bids=PublicKey(con.bids),
-            asks=PublicKey(con.asks),
-            base_lot_size=con.base_lot_size,
-            quote_lot_size=con.quote_lot_size,
-            fee_rate_bps=con.fee_rate_bps,
-            base_spl_token_decimals=base_mint_decimals,
-            quote_spl_token_decimals=quote_mint_decimals,
-            program_id=program_id,
-            skip_preflight=False,
-            confirmations=10,
-        )
-
-
-def get_mint_decimals(conn: Client, mint_pub_key: PublicKey) -> int:
-    """Get the mint decimals from given public key."""
-    bytes_data = load_bytes_data(mint_pub_key, conn)
-    return MINT_LAYOUT.parse(bytes_data).decimals
+        return int(math.floor(size * 10 ** self._base_mint_decimals) / self.base_lot_size())

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -46,7 +46,7 @@ class MarketState:  # pylint: disable=too-many-public-methods
         return PublicKey(self._decoded.own_address)
 
     def account_flags(self) -> AccountFlags:
-        return AccountFlags.init(self._decoded.account_flags)
+        return AccountFlags(**self._decoded.account_flags)
 
     def asks(self) -> PublicKey:
         return PublicKey(self._decoded.asks)

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -90,16 +90,16 @@ class MarketState:  # pylint: disable=too-many-public-methods
         return self._decoded.vault_signer_nonce
 
     def base_mint(self) -> PublicKey:
-        return self._decoded.base_mint
+        return PublicKey(self._decoded.base_mint)
 
     def quote_mint(self) -> PublicKey:
-        return self._decoded.quote_mint
+        return PublicKey(self._decoded.quote_mint)
 
     def base_vault(self) -> PublicKey:
-        return self._decoded.base_vault
+        return PublicKey(self._decoded.base_vault)
 
     def quote_vault(self) -> PublicKey:
-        return self._decoded.quote_vault
+        return PublicKey(self._decoded.quote_vault)
 
     def base_deposits_total(self) -> int:
         return self._decoded.base_deposits_total

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -23,7 +23,7 @@ class AccountFlags(NamedTuple):
 
     @staticmethod
     # Argument is construct parsed account flags.
-    def init(con: Any) -> AccountFlags:
+    def init(con: Container) -> AccountFlags:
         return AccountFlags(
             initialized=con.initialized,
             market=con.market,

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import math
 
+from typing import Sequence
+
 from construct import Container, Struct  # type: ignore
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
@@ -37,6 +39,18 @@ class MarketState:  # pylint: disable=too-many-public-methods
 
         base_mint_decimals = get_mint_decimals(conn, PublicKey(parsed_market.base_mint))
         quote_mint_decimals = get_mint_decimals(conn, PublicKey(parsed_market.quote_mint))
+        return MarketState(parsed_market, program_id, base_mint_decimals, quote_mint_decimals)
+
+    @staticmethod
+    def from_bytes(
+        program_id: PublicKey, base_mint_decimals: int, quote_mint_decimals: int, buffer: Sequence[int]
+    ) -> MarketState:
+        parsed_market = MARKET_LAYOUT.parse(buffer)
+        # TODO: add ownAddress check!
+
+        if not parsed_market.account_flags.initialized or not parsed_market.account_flags.market:
+            raise Exception("Invalid market")
+
         return MarketState(parsed_market, program_id, base_mint_decimals, quote_mint_decimals)
 
     def program_id(self) -> PublicKey:

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-from typing import NamedTuple
 
 from construct import Container, Struct  # type: ignore
 from solana.publickey import PublicKey
@@ -10,29 +9,7 @@ from solana.rpc.api import Client
 from src.utils import get_mint_decimals, load_bytes_data
 
 from .._layouts.market import MARKET_LAYOUT
-
-
-class AccountFlags(NamedTuple):
-    initialized: bool = False
-    market: bool = False
-    open_orders: bool = False
-    request_queue: bool = False
-    event_queue: bool = False
-    bids: bool = False
-    asks: bool = False
-
-    @staticmethod
-    # Argument is construct parsed account flags.
-    def init(con: Container) -> AccountFlags:
-        return AccountFlags(
-            initialized=con.initialized,
-            market=con.market,
-            open_orders=con.open_orders,
-            request_queue=con.request_queue,
-            event_queue=con.event_queue,
-            bids=con.bids,
-            asks=con.asks,
-        )
+from .types import AccountFlags
 
 
 class MarketState:  # pylint: disable=too-many-public-methods

--- a/src/market/state.py
+++ b/src/market/state.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-
 from typing import Sequence
 
 from construct import Container, Struct  # type: ignore

--- a/src/market/types.py
+++ b/src/market/types.py
@@ -10,12 +10,19 @@ from ..enums import Side
 
 class AccountFlags(NamedTuple):
     initialized: bool = False
+    """"""
     market: bool = False
+    """"""
     open_orders: bool = False
+    """"""
     request_queue: bool = False
+    """"""
     event_queue: bool = False
+    """"""
     bids: bool = False
+    """"""
     asks: bool = False
+    """"""
 
     @staticmethod
     def from_bytes(date_bytes: bytes) -> AccountFlags:
@@ -31,26 +38,49 @@ class AccountFlags(NamedTuple):
         )
 
 
+class MarketOpts(NamedTuple):
+    skip_preflight: bool = False
+    """"""
+    confirmations: int = 10
+    """"""
+
+
 class FilledOrder(NamedTuple):
     order_id: int
+    """"""
     side: Side
+    """"""
     price: float
+    """"""
     size: float
+    """"""
     fee_cost: int
+    """"""
 
 
 class OrderInfo(NamedTuple):
     price: float
+    """"""
     size: float
+    """"""
     price_lots: int
+    """"""
     size_lots: int
+    """"""
 
 
 class Order(NamedTuple):
     order_id: int
+    """"""
     client_id: int
+    """"""
     open_order_address: PublicKey
+    """"""
     open_order_slot: int
+    """"""
     fee_tier: int
+    """"""
     order_info: OrderInfo
+    """"""
     side: Side
+    """"""

--- a/src/market/types.py
+++ b/src/market/types.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-from construct import Container
 from solana.publickey import PublicKey
 
+from .._layouts.account_flags import ACCOUNT_FLAGS_LAYOUT
 from ..enums import Side
 
 
@@ -18,7 +18,8 @@ class AccountFlags(NamedTuple):
     asks: bool = False
 
     @staticmethod
-    def init(con: Container) -> AccountFlags:
+    def from_bytes(date_bytes: bytes) -> AccountFlags:
+        con = ACCOUNT_FLAGS_LAYOUT.parse(date_bytes)
         return AccountFlags(
             initialized=con.initialized,
             market=con.market,

--- a/src/market/types.py
+++ b/src/market/types.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from construct import Container
+from solana.publickey import PublicKey
+
+from ..enums import Side
+
+
+class AccountFlags(NamedTuple):
+    initialized: bool = False
+    market: bool = False
+    open_orders: bool = False
+    request_queue: bool = False
+    event_queue: bool = False
+    bids: bool = False
+    asks: bool = False
+
+    @staticmethod
+    def init(con: Container) -> AccountFlags:
+        return AccountFlags(
+            initialized=con.initialized,
+            market=con.market,
+            open_orders=con.open_orders,
+            request_queue=con.request_queue,
+            event_queue=con.event_queue,
+            bids=con.bids,
+            asks=con.asks,
+        )
+
+
+class FilledOrder(NamedTuple):
+    order_id: int
+    side: Side
+    price: float
+    size: float
+    fee_cost: int
+
+
+class OrderInfo(NamedTuple):
+    price: float
+    size: float
+    price_lots: int
+    size_lots: int
+
+
+class Order(NamedTuple):
+    order_id: int
+    client_id: int
+    open_order_address: PublicKey
+    open_order_slot: int
+    fee_tier: int
+    order_info: OrderInfo
+    side: Side

--- a/src/market/types.py
+++ b/src/market/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import NamedTuple, Sequence
 
 from solana.publickey import PublicKey
 
@@ -25,8 +25,8 @@ class AccountFlags(NamedTuple):
     """"""
 
     @staticmethod
-    def from_bytes(date_bytes: bytes) -> AccountFlags:
-        con = ACCOUNT_FLAGS_LAYOUT.parse(date_bytes)
+    def from_bytes(buffer: Sequence[int]) -> AccountFlags:
+        con = ACCOUNT_FLAGS_LAYOUT.parse(buffer)
         return AccountFlags(
             initialized=con.initialized,
             market=con.market,

--- a/src/open_orders_account.py
+++ b/src/open_orders_account.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Sequence
 
 from solana.publickey import PublicKey
 from solana.rpc.api import Client, MemcmpOpt
@@ -51,8 +51,8 @@ class OpenOrdersAccount:
         self.client_ids = client_ids
 
     @staticmethod
-    def from_bytes(address: PublicKey, data_bytes: bytes) -> OpenOrdersAccount:
-        open_order_decoded = OPEN_ORDERS_LAYOUT.parse(data_bytes)
+    def from_bytes(address: PublicKey, buffer: Sequence[int]) -> OpenOrdersAccount:
+        open_order_decoded = OPEN_ORDERS_LAYOUT.parse(buffer)
         if not open_order_decoded.account_flags.open_orders or not open_order_decoded.account_flags.initialized:
             raise Exception("Not an open order account or not initialized.")
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,8 @@ import base64
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 
+from src._layouts.market import MINT_LAYOUT
+
 
 def load_bytes_data(addr: PublicKey, conn: Client):
     res = conn.get_account_info(addr)
@@ -10,3 +12,9 @@ def load_bytes_data(addr: PublicKey, conn: Client):
         raise Exception("Cannot load byte data.")
     data = res["result"]["value"]["data"][0]
     return base64.decodebytes(data.encode("ascii"))
+
+
+def get_mint_decimals(conn: Client, mint_pub_key: PublicKey) -> int:
+    """Get the mint decimals for a token mint"""
+    bytes_data = load_bytes_data(mint_pub_key, conn)
+    return MINT_LAYOUT.parse(bytes_data).decimals

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from solana.account import Account
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 
-from src.client import market_client
+from src.connection import conn
 
 
 @pytest.mark.integration
@@ -146,7 +146,7 @@ def stubbed_ask_account_pk(__bs_params) -> PublicKey:
 @pytest.fixture(scope="session")
 def http_client() -> Client:
     """Solana http client."""
-    client = market_client("http://localhost:8899")
-    if not client.is_connected():
+    cc = conn("http://localhost:8899")  # pylint: disable=invalid-name
+    if not cc.is_connected():
         raise Exception("Could not connect to local node. Please run `make int-tests` to run integration tests.")
-    return client
+    return cc

--- a/tests/integration/test_market.py
+++ b/tests/integration/test_market.py
@@ -13,7 +13,7 @@ from .utils import confirm_transaction
 @pytest.mark.integration
 @pytest.fixture(scope="module")
 def bootstrapped_market(http_client: Client, stubbed_market_pk: PublicKey, stubbed_dex_program_pk: PublicKey) -> Market:
-    return Market.load(http_client, stubbed_market_pk, None, stubbed_dex_program_pk)
+    return Market.load(http_client, stubbed_market_pk, stubbed_dex_program_pk)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_market.py
+++ b/tests/integration/test_market.py
@@ -13,7 +13,7 @@ from .utils import confirm_transaction
 @pytest.mark.integration
 @pytest.fixture(scope="module")
 def bootstrapped_market(http_client: Client, stubbed_market_pk: PublicKey, stubbed_dex_program_pk: PublicKey) -> Market:
-    return Market.load(http_client, str(stubbed_market_pk), None, stubbed_dex_program_pk)
+    return Market.load(http_client, stubbed_market_pk, None, stubbed_dex_program_pk)
 
 
 @pytest.mark.integration
@@ -25,7 +25,7 @@ def test_bootstrapped_market(
     stubbed_quote_mint: PublicKey,
 ):
     assert isinstance(bootstrapped_market, Market)
-    assert bootstrapped_market.public_key() == stubbed_market_pk
+    assert bootstrapped_market.state.public_key() == stubbed_market_pk
     assert bootstrapped_market.state.program_id() == stubbed_dex_program_pk
     assert bootstrapped_market.state.base_mint() == stubbed_base_mint.public_key()
     assert bootstrapped_market.state.quote_mint() == stubbed_quote_mint.public_key()

--- a/tests/integration/test_market.py
+++ b/tests/integration/test_market.py
@@ -25,10 +25,10 @@ def test_bootstrapped_market(
     stubbed_quote_mint: PublicKey,
 ):
     assert isinstance(bootstrapped_market, Market)
-    assert bootstrapped_market.state.own_address == stubbed_market_pk
-    assert bootstrapped_market.state.program_id == stubbed_dex_program_pk
-    assert bootstrapped_market.state.base_mint == stubbed_base_mint.public_key()
-    assert bootstrapped_market.state.quote_mint == stubbed_quote_mint.public_key()
+    assert bootstrapped_market.public_key() == stubbed_market_pk
+    assert bootstrapped_market.state.program_id() == stubbed_dex_program_pk
+    assert bootstrapped_market.state.base_mint() == stubbed_base_mint.public_key()
+    assert bootstrapped_market.state.quote_mint() == stubbed_quote_mint.public_key()
 
 
 @pytest.mark.integration

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -5,7 +5,8 @@ from construct import Container
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 
-from src.market import AccountFlags, Market, MarketState, Order, OrderBook, OrderInfo
+from src.market import Market, State, OrderBook
+from src.market.types import AccountFlags, Order, OrderInfo
 
 from .binary_file_path import ASK_ORDER_BIN_PATH
 
@@ -28,7 +29,7 @@ def stubbed_data() -> bytes:
 @pytest.fixture(scope="module")
 def stubbed_market() -> Market:
     conn = Client("http://stubbed_endpoint:123/")
-    market_state = MarketState(
+    market_state = State(
         Container(
             dict(
                 account_flags=AccountFlags(
@@ -49,7 +50,7 @@ def stubbed_market() -> Market:
 
 
 def test_parse_market_state(stubbed_data):  # pylint: disable=redefined-outer-name
-    parsed_market = MarketState.LAYOUT().parse(stubbed_data)
+    parsed_market = State.LAYOUT().parse(stubbed_data)
     assert parsed_market.account_flags.initialized
     assert parsed_market.account_flags.market
     assert not parsed_market.account_flags.open_orders

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -5,7 +5,7 @@ from construct import Container
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 
-from src.market import Market, State, OrderBook
+from src.market import Market, OrderBook, State
 from src.market.types import AccountFlags, Order, OrderInfo
 
 from .binary_file_path import ASK_ORDER_BIN_PATH

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -65,7 +65,7 @@ def test_order_book_iterator(stubbed_market):  # pylint: disable=redefined-outer
     with open(ASK_ORDER_BIN_PATH, "r") as input_file:
         base64_res = input_file.read()
         data = base64.decodebytes(base64_res.encode("ascii"))
-        order_book = OrderBook.decode(stubbed_market, data)
+        order_book = OrderBook.decode(stubbed_market.state, data)
         total_orders = sum([1 for _ in order_book.orders()])
         assert total_orders == 15
 
@@ -74,7 +74,7 @@ def test_order_book_get_l2(stubbed_market):  # pylint: disable=redefined-outer-n
     with open(ASK_ORDER_BIN_PATH, "r") as input_file:
         base64_res = input_file.read()
         data = base64.decodebytes(base64_res.encode("ascii"))
-        order_book = OrderBook.decode(stubbed_market, data)
+        order_book = OrderBook.decode(stubbed_market.state, data)
         for i in range(1, 16):
             assert i == len(order_book.get_l2(i))
         assert [OrderInfo(11744.6, 4.0632, 117446, 40632)] == order_book.get_l2(1)
@@ -84,7 +84,7 @@ def test_order_book_iterable(stubbed_market):  # pylint: disable=redefined-outer
     with open(ASK_ORDER_BIN_PATH, "r") as input_file:
         base64_res = input_file.read()
         data = base64.decodebytes(base64_res.encode("ascii"))
-        order_book = OrderBook.decode(stubbed_market, data)
+        order_book = OrderBook.decode(stubbed_market.state, data)
         cnt = 0
         for order in order_book:
             cnt += 1

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -2,9 +2,9 @@ import base64
 
 import pytest
 from construct import Container
-from solana.publickey import PublicKey
 from solana.rpc.api import Client
 
+from src.instructions import DEFAULT_DEX_PROGRAM_ID
 from src.market import Market, OrderBook, State
 from src.market.types import AccountFlags, Order, OrderInfo
 
@@ -42,11 +42,11 @@ def stubbed_market() -> Market:
                 quote_lot_size=10,
             )
         ),
-        program_id=PublicKey(123),
+        program_id=DEFAULT_DEX_PROGRAM_ID,
         base_mint_decimals=6,
         quote_mint_decimals=6,
     )
-    return Market(conn, market_state, None)
+    return Market(conn, market_state)
 
 
 def test_parse_market_state(stubbed_data):  # pylint: disable=redefined-outer-name

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -65,7 +65,7 @@ def test_order_book_iterator(stubbed_market):  # pylint: disable=redefined-outer
     with open(ASK_ORDER_BIN_PATH, "r") as input_file:
         base64_res = input_file.read()
         data = base64.decodebytes(base64_res.encode("ascii"))
-        order_book = OrderBook.decode(stubbed_market.state, data)
+        order_book = OrderBook.from_bytes(stubbed_market.state, data)
         total_orders = sum([1 for _ in order_book.orders()])
         assert total_orders == 15
 
@@ -74,7 +74,7 @@ def test_order_book_get_l2(stubbed_market):  # pylint: disable=redefined-outer-n
     with open(ASK_ORDER_BIN_PATH, "r") as input_file:
         base64_res = input_file.read()
         data = base64.decodebytes(base64_res.encode("ascii"))
-        order_book = OrderBook.decode(stubbed_market.state, data)
+        order_book = OrderBook.from_bytes(stubbed_market.state, data)
         for i in range(1, 16):
             assert i == len(order_book.get_l2(i))
         assert [OrderInfo(11744.6, 4.0632, 117446, 40632)] == order_book.get_l2(1)
@@ -84,7 +84,7 @@ def test_order_book_iterable(stubbed_market):  # pylint: disable=redefined-outer
     with open(ASK_ORDER_BIN_PATH, "r") as input_file:
         base64_res = input_file.read()
         data = base64.decodebytes(base64_res.encode("ascii"))
-        order_book = OrderBook.decode(stubbed_market.state, data)
+        order_book = OrderBook.from_bytes(stubbed_market.state, data)
         cnt = 0
         for order in order_book:
             cnt += 1

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -57,7 +57,7 @@ def test_parse_slab():
 
 
 def test_slab_get():
-    slab = Slab.decode(DATA)
+    slab = Slab.from_bytes(DATA)
     assert slab.get(123456789012345678901234567890).owner_slot == 1
     assert slab.get(100000000000000000000000000000).owner_slot == 2
     assert slab.get(200000000000000000000000000000).owner_slot == 3
@@ -74,12 +74,12 @@ def test_slab_get():
 
 
 def test_length_of_slab_iterator():
-    slab = Slab.decode(DATA)
+    slab = Slab.from_bytes(DATA)
     assert sum(1 for _ in slab.items()) == 4
 
 
 def test_iterate_in_ascending_order():
-    slab = Slab.decode(DATA)
+    slab = Slab.from_bytes(DATA)
     prev = None
     for node in slab.items():
         curr_key = node.key
@@ -89,7 +89,7 @@ def test_iterate_in_ascending_order():
 
 
 def test_iterate_in_descending_order():
-    slab = Slab.decode(DATA)
+    slab = Slab.from_bytes(DATA)
     prev = None
     for node in slab.items(descending=True):
         curr_key = node.key


### PR DESCRIPTION
- Refactored `MarketState` easier to make it easier to maintain if the underlying market layout changes on the Serum side.
- Refactored out all market-related types
- Rename all `decode` methods to `from_bytes`
- Other general clean ups