### PR TITLE
in market.parse_fill_event, event.order_id is already an int

### DIFF
--- a/pyserum/market/market.py
+++ b/pyserum/market/market.py
@@ -145,7 +145,7 @@ class Market:
         )
         size = event.native_quantity_paid / self.state.base_spl_token_multiplier()
         return t.FilledOrder(
-            order_id=int.from_bytes(event.order_id, "little"),
+            order_id=event.order_id,
             side=side,
             price=price,
             size=size,


### PR DESCRIPTION
In market.parse_fill_event, no need to cast event.order_id to int as it's already one.
Doing so raises an exception whenever I try to get fills, this fixes it.