### PR TITLE
Fixed size bug.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,6 +29,7 @@ sphinxemoji = "*"
 [packages]
 solana = "*"
 construct = "*"
+flake8 = "*"
 
 [requires]
 python_version = "3.7"

--- a/pyserum/_layouts/instructions.py
+++ b/pyserum/_layouts/instructions.py
@@ -9,16 +9,16 @@ from .slab import KEY
 
 
 class InstructionType(IntEnum):
-    InitializeMarket = 0
-    NewOrder = 1
-    MatchOrder = 2
-    ConsumeEvents = 3
-    CancelOrder = 4
-    SettleFunds = 5
-    CancelOrderByClientID = 6
-    NewOrderV3 = 10
-    CancelOrderV2 = 11
-    CancelOrderByClientIdV2 = 12
+    INITIALIZE_MARKET = 0
+    NEW_ORDER = 1
+    MATCH_ORDER = 2
+    CONSUME_EVENTS = 3
+    CANCEL_ORDER = 4
+    SETTLE_FUNDS = 5
+    CANCEL_ORDER_BY_CLIENT_ID = 6
+    NEW_ORDER_V3 = 10
+    CANCEL_ORDER_V2 = 11
+    CANCEL_ORDER_BY_CLIENT_ID_V2 = 12
 
 
 _VERSION = 0
@@ -77,16 +77,16 @@ INSTRUCTIONS_LAYOUT = cStruct(
     / Switch(
         lambda this: this.instruction_type,
         {
-            InstructionType.InitializeMarket: _INITIALIZE_MARKET,
-            InstructionType.NewOrder: _NEW_ORDER,
-            InstructionType.MatchOrder: _MATCH_ORDERS,
-            InstructionType.ConsumeEvents: _CONSUME_EVENTS,
-            InstructionType.CancelOrder: _CANCEL_ORDER,
-            InstructionType.SettleFunds: Pass,  # Empty list
-            InstructionType.CancelOrderByClientID: _CANCEL_ORDER_BY_CLIENTID,
-            InstructionType.NewOrderV3: _NEW_ORDER_V3,
-            InstructionType.CancelOrderV2: _CANCEL_ORDER_V2,
-            InstructionType.CancelOrderByClientIdV2: _CANCEL_ORDER_BY_CLIENTID_V2,
+            InstructionType.INITIALIZE_MARKET: _INITIALIZE_MARKET,
+            InstructionType.NEW_ORDER: _NEW_ORDER,
+            InstructionType.MATCH_ORDER: _MATCH_ORDERS,
+            InstructionType.CONSUME_EVENTS: _CONSUME_EVENTS,
+            InstructionType.CANCEL_ORDER: _CANCEL_ORDER,
+            InstructionType.SETTLE_FUNDS: Pass,  # Empty list
+            InstructionType.CANCEL_ORDER_BY_CLIENT_ID: _CANCEL_ORDER_BY_CLIENTID,
+            InstructionType.NEW_ORDER_V3: _NEW_ORDER_V3,
+            InstructionType.CANCEL_ORDER_V2: _CANCEL_ORDER_V2,
+            InstructionType.CANCEL_ORDER_BY_CLIENT_ID_V2: _CANCEL_ORDER_BY_CLIENTID_V2,
         },
     ),
 )

--- a/pyserum/enums.py
+++ b/pyserum/enums.py
@@ -6,24 +6,24 @@ from enum import IntEnum
 class Side(IntEnum):
     """Side of the orderbook to trade."""
 
-    Buy = 0
+    BUY = 0
     """"""
-    Sell = 1
+    SELL = 1
     """"""
 
 
 class OrderType(IntEnum):
     """"Type of order."""
 
-    Limit = 0
+    LIMIT = 0
     """"""
     IOC = 1
     """"""
-    PostOnly = 2
+    POST_ONLY = 2
     """"""
 
 
 class SelfTradeBehavior(IntEnum):
-    DecrementTake = 0
-    CancelProvide = 1
-    AbortTransaction = 2
+    DECREMENT_TAKE = 0
+    CANCEL_PROVIDE = 1
+    ABORT_TRANSACTION = 2

--- a/pyserum/instructions.py
+++ b/pyserum/instructions.py
@@ -269,16 +269,16 @@ class CancelOrderByClientIDV2Params(NamedTuple):
 
 def __parse_and_validate_instruction(instruction: TransactionInstruction, instruction_type: InstructionType) -> Any:
     instruction_type_to_length_map: Dict[InstructionType, int] = {
-        InstructionType.InitializeMarket: 9,
-        InstructionType.NewOrder: 9,
-        InstructionType.MatchOrder: 7,
-        InstructionType.ConsumeEvents: 2,
-        InstructionType.CancelOrder: 4,
-        InstructionType.CancelOrderByClientID: 4,
-        InstructionType.SettleFunds: 9,
-        InstructionType.NewOrderV3: 12,
-        InstructionType.CancelOrderV2: 6,
-        InstructionType.CancelOrderByClientIdV2: 6,
+        InstructionType.INITIALIZE_MARKET: 9,
+        InstructionType.NEW_ORDER: 9,
+        InstructionType.MATCH_ORDER: 7,
+        InstructionType.CONSUME_EVENTS: 2,
+        InstructionType.CANCEL_ORDER: 4,
+        InstructionType.CANCEL_ORDER_BY_CLIENT_ID: 4,
+        InstructionType.SETTLE_FUNDS: 9,
+        InstructionType.NEW_ORDER_V3: 12,
+        InstructionType.CANCEL_ORDER_V2: 6,
+        InstructionType.CANCEL_ORDER_BY_CLIENT_ID_V2: 6,
     }
     validate_instruction_keys(instruction, instruction_type_to_length_map[instruction_type])
     data = INSTRUCTIONS_LAYOUT.parse(instruction.data)
@@ -288,7 +288,7 @@ def __parse_and_validate_instruction(instruction: TransactionInstruction, instru
 
 def decode_initialize_market(instruction: TransactionInstruction) -> InitializeMarketParams:
     """Decode an instialize market instruction and retrieve the instruction params."""
-    data = __parse_and_validate_instruction(instruction, InstructionType.InitializeMarket)
+    data = __parse_and_validate_instruction(instruction, InstructionType.INITIALIZE_MARKET)
     return InitializeMarketParams(
         market=instruction.keys[0].pubkey,
         request_queue=instruction.keys[1].pubkey,
@@ -309,7 +309,7 @@ def decode_initialize_market(instruction: TransactionInstruction) -> InitializeM
 
 
 def decode_new_order(instruction: TransactionInstruction) -> NewOrderParams:
-    data = __parse_and_validate_instruction(instruction, InstructionType.NewOrder)
+    data = __parse_and_validate_instruction(instruction, InstructionType.NEW_ORDER)
     return NewOrderParams(
         market=instruction.keys[0].pubkey,
         open_orders=instruction.keys[1].pubkey,
@@ -328,7 +328,7 @@ def decode_new_order(instruction: TransactionInstruction) -> NewOrderParams:
 
 def decode_match_orders(instruction: TransactionInstruction) -> MatchOrdersParams:
     """Decode a match orders instruction and retrieve the instruction params."""
-    data = __parse_and_validate_instruction(instruction, InstructionType.MatchOrder)
+    data = __parse_and_validate_instruction(instruction, InstructionType.MATCH_ORDER)
     return MatchOrdersParams(
         market=instruction.keys[0].pubkey,
         request_queue=instruction.keys[1].pubkey,
@@ -343,7 +343,7 @@ def decode_match_orders(instruction: TransactionInstruction) -> MatchOrdersParam
 
 def decode_consume_events(instruction: TransactionInstruction) -> ConsumeEventsParams:
     """Decode a consume events instruction and retrieve the instruction params."""
-    data = __parse_and_validate_instruction(instruction, InstructionType.ConsumeEvents)
+    data = __parse_and_validate_instruction(instruction, InstructionType.CONSUME_EVENTS)
     return ConsumeEventsParams(
         open_orders_accounts=[a_m.pubkey for a_m in instruction.keys[:-2]],
         market=instruction.keys[-2].pubkey,
@@ -353,7 +353,7 @@ def decode_consume_events(instruction: TransactionInstruction) -> ConsumeEventsP
 
 
 def decode_cancel_order(instruction: TransactionInstruction) -> CancelOrderParams:
-    data = __parse_and_validate_instruction(instruction, InstructionType.CancelOrder)
+    data = __parse_and_validate_instruction(instruction, InstructionType.CANCEL_ORDER)
     return CancelOrderParams(
         market=instruction.keys[0].pubkey,
         open_orders=instruction.keys[1].pubkey,
@@ -380,7 +380,7 @@ def decode_settle_funds(instruction: TransactionInstruction) -> SettleFundsParam
 
 
 def decode_cancel_order_by_client_id(instruction: TransactionInstruction) -> CancelOrderByClientIDParams:
-    data = __parse_and_validate_instruction(instruction, InstructionType.CancelOrderByClientID)
+    data = __parse_and_validate_instruction(instruction, InstructionType.CANCEL_ORDER_BY_CLIENT_ID)
     return CancelOrderByClientIDParams(
         market=instruction.keys[0].pubkey,
         open_orders=instruction.keys[1].pubkey,
@@ -391,7 +391,7 @@ def decode_cancel_order_by_client_id(instruction: TransactionInstruction) -> Can
 
 
 def decode_new_order_v3(instruction: TransactionInstruction) -> NewOrderV3Params:
-    data = __parse_and_validate_instruction(instruction, InstructionType.NewOrderV3)
+    data = __parse_and_validate_instruction(instruction, InstructionType.NEW_ORDER_V3)
     return NewOrderV3Params(
         market=instruction.keys[0].pubkey,
         open_orders=instruction.keys[1].pubkey,
@@ -415,7 +415,7 @@ def decode_new_order_v3(instruction: TransactionInstruction) -> NewOrderV3Params
 
 
 def decode_cancel_order_v2(instruction: TransactionInstruction) -> CancelOrderV2Params:
-    data = __parse_and_validate_instruction(instruction, InstructionType.CancelOrderV2)
+    data = __parse_and_validate_instruction(instruction, InstructionType.CANCEL_ORDER_V2)
     return CancelOrderV2Params(
         market=instruction.keys[0].pubkey,
         bids=instruction.keys[1].pubkey,
@@ -430,7 +430,7 @@ def decode_cancel_order_v2(instruction: TransactionInstruction) -> CancelOrderV2
 
 
 def decode_cancel_order_by_client_id_v2(instruction: TransactionInstruction) -> CancelOrderByClientIDV2Params:
-    data = __parse_and_validate_instruction(instruction, InstructionType.CancelOrderByClientIdV2)
+    data = __parse_and_validate_instruction(instruction, InstructionType.CANCEL_ORDER_BY_CLIENT_ID_V2)
     return CancelOrderByClientIDV2Params(
         market=instruction.keys[0].pubkey,
         bids=instruction.keys[1].pubkey,
@@ -459,7 +459,7 @@ def initialize_market(params: InitializeMarketParams) -> TransactionInstruction:
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
             dict(
-                instruction_type=InstructionType.InitializeMarket,
+                instruction_type=InstructionType.INITIALIZE_MARKET,
                 args=dict(
                     base_lot_size=params.base_lot_size,
                     quote_lot_size=params.quote_lot_size,
@@ -489,7 +489,7 @@ def new_order(params: NewOrderParams) -> TransactionInstruction:
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
             dict(
-                instruction_type=InstructionType.NewOrder,
+                instruction_type=InstructionType.NEW_ORDER,
                 args=dict(
                     side=params.side,
                     limit_price=params.limit_price,
@@ -516,7 +516,7 @@ def match_orders(params: MatchOrdersParams) -> TransactionInstruction:
         ],
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
-            dict(instruction_type=InstructionType.MatchOrder, args=dict(limit=params.limit))
+            dict(instruction_type=InstructionType.MATCH_ORDER, args=dict(limit=params.limit))
         ),
     )
 
@@ -531,7 +531,7 @@ def consume_events(params: ConsumeEventsParams) -> TransactionInstruction:
         keys=keys,
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
-            dict(instruction_type=InstructionType.ConsumeEvents, args=dict(limit=params.limit))
+            dict(instruction_type=InstructionType.CONSUME_EVENTS, args=dict(limit=params.limit))
         ),
     )
 
@@ -548,7 +548,7 @@ def cancel_order(params: CancelOrderParams) -> TransactionInstruction:
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
             dict(
-                instruction_type=InstructionType.CancelOrder,
+                instruction_type=InstructionType.CANCEL_ORDER,
                 args=dict(
                     side=params.side,
                     order_id=params.order_id.to_bytes(16, byteorder="little"),
@@ -575,7 +575,7 @@ def settle_funds(params: SettleFundsParams) -> TransactionInstruction:
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ],
         program_id=params.program_id,
-        data=INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.SettleFunds, args=dict())),
+        data=INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.SETTLE_FUNDS, args=dict())),
     )
 
 
@@ -591,7 +591,7 @@ def cancel_order_by_client_id(params: CancelOrderByClientIDParams) -> Transactio
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
             dict(
-                instruction_type=InstructionType.CancelOrderByClientID,
+                instruction_type=InstructionType.CANCEL_ORDER_BY_CLIENT_ID,
                 args=dict(
                     client_id=params.client_id,
                 ),
@@ -625,7 +625,7 @@ def new_order_v3(params: NewOrderV3Params) -> TransactionInstruction:
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
             dict(
-                instruction_type=InstructionType.NewOrderV3,
+                instruction_type=InstructionType.NEW_ORDER_V3,
                 args=dict(
                     side=params.side,
                     limit_price=params.limit_price,
@@ -655,7 +655,7 @@ def cancel_order_v2(params: CancelOrderV2Params) -> TransactionInstruction:
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
             dict(
-                instruction_type=InstructionType.CancelOrderV2,
+                instruction_type=InstructionType.CANCEL_ORDER_V2,
                 args=dict(
                     side=params.side,
                     order_id=params.order_id.to_bytes(16, byteorder="little"),
@@ -679,7 +679,7 @@ def cancel_order_by_client_id_v2(params: CancelOrderByClientIDV2Params) -> Trans
         program_id=params.program_id,
         data=INSTRUCTIONS_LAYOUT.build(
             dict(
-                instruction_type=InstructionType.CancelOrderByClientIdV2,
+                instruction_type=InstructionType.CANCEL_ORDER_BY_CLIENT_ID_V2,
                 args=dict(
                     client_id=params.client_id,
                 ),

--- a/pyserum/market/_internal/queue.py
+++ b/pyserum/market/_internal/queue.py
@@ -10,15 +10,15 @@ from ..types import Event, EventFlags, Request, ReuqestFlags
 
 
 class QueueType(IntEnum):
-    Event = 1
-    Request = 2
+    EVENT = 1
+    REQUEST = 2
 
 
 def __from_bytes(
     buffer: Sequence[int], queue_type: QueueType, history: Optional[int]
 ) -> Tuple[Container, List[Union[Event, Request]]]:
     header = QUEUE_HEADER_LAYOUT.parse(buffer)
-    layout_size = EVENT_LAYOUT.sizeof() if queue_type == QueueType.Event else REQUEST_LAYOUT.sizeof()
+    layout_size = EVENT_LAYOUT.sizeof() if queue_type == QueueType.EVENT else REQUEST_LAYOUT.sizeof()
     alloc_len = math.floor((len(buffer) - QUEUE_HEADER_LAYOUT.sizeof()) / layout_size)
     nodes: List[Union[Event, Request]] = []
     if history:
@@ -35,7 +35,7 @@ def __from_bytes(
 
 
 def __parse_queue_item(buffer: Sequence[int], queue_type: QueueType) -> Union[Event, Request]:
-    if queue_type == QueueType.Event:  # pylint: disable=no-else-return
+    if queue_type == QueueType.EVENT:  # pylint: disable=no-else-return
         parsed_item = EVENT_LAYOUT.parse(buffer)
         parsed_event_flags = parsed_item.event_flags
         event_flags = EventFlags(
@@ -80,14 +80,14 @@ def __parse_queue_item(buffer: Sequence[int], queue_type: QueueType) -> Union[Ev
 
 
 def decode_request_queue(buffer: bytes, history: Optional[int] = None) -> List[Request]:
-    header, nodes = __from_bytes(buffer, QueueType.Request, history)
+    header, nodes = __from_bytes(buffer, QueueType.REQUEST, history)
     if not header.account_flags.initialized or not header.account_flags.request_queue:
         raise Exception("Invalid requests queue, either not initialized or not a request queue.")
     return cast(List[Request], nodes)
 
 
 def decode_event_queue(buffer: bytes, history: Optional[int] = None) -> List[Event]:
-    header, nodes = __from_bytes(buffer, QueueType.Event, history)
+    header, nodes = __from_bytes(buffer, QueueType.EVENT, history)
     if not header.account_flags.initialized or not header.account_flags.event_queue:
         raise Exception("Invalid events queue, either not initialized or not a event queue.")
     return cast(List[Event], nodes)

--- a/pyserum/market/market.py
+++ b/pyserum/market/market.py
@@ -319,7 +319,9 @@ class Market:
                 side=side,
                 limit_price=self.state.price_number_to_lots(limit_price),
                 max_base_quantity=self.state.base_size_number_to_lots(max_quantity),
-                max_quote_quantity=self.state.base_size_number_to_lots(max_quantity) * self.state.quote_lot_size() * self.state.price_number_to_lots(limit_price),
+                max_quote_quantity=self.state.base_size_number_to_lots(max_quantity)
+                * self.state.quote_lot_size()
+                * self.state.price_number_to_lots(limit_price),
                 order_type=order_type,
                 client_id=client_id,
                 program_id=self.state.program_id(),

--- a/pyserum/market/market.py
+++ b/pyserum/market/market.py
@@ -199,8 +199,8 @@ class Market:
             raise ValueError("Invalid payer account")
 
         # TODO: add integration test for SOL wrapping.
-        should_wrap_sol = (side == side.Buy and self.state.quote_mint() == WRAPPED_SOL_MINT) or (
-            side == side.Sell and self.state.base_mint == WRAPPED_SOL_MINT
+        should_wrap_sol = (side == Side.BUY and self.state.quote_mint() == WRAPPED_SOL_MINT) or (
+            side == Side.SELL and self.state.base_mint == WRAPPED_SOL_MINT
         )
         wrapped_sol_account = Account()
         if should_wrap_sol:

--- a/pyserum/market/market.py
+++ b/pyserum/market/market.py
@@ -319,7 +319,7 @@ class Market:
                 side=side,
                 limit_price=self.state.price_number_to_lots(limit_price),
                 max_base_quantity=self.state.base_size_number_to_lots(max_quantity),
-                max_quote_quantity=self.state.quote_size_number_to_lots(max_quantity * limit_price),
+                max_quote_quantity=self.state.base_size_number_to_lots(max_quantity) * self.state.quote_lot_size() * self.state.price_number_to_lots(limit_price),
                 order_type=order_type,
                 client_id=client_id,
                 program_id=self.state.program_id(),

--- a/pyserum/market/market.py
+++ b/pyserum/market/market.py
@@ -137,14 +137,14 @@ class Market:
 
     def parse_fill_event(self, event) -> t.FilledOrder:
         if event.event_flags.bid:
-            side = Side.Buy
+            side = Side.BUY
             price_before_fees = (
                 event.native_quantity_released + event.native_fee_or_rebate
                 if event.event_flags.maker
                 else event.native_quantity_released - event.native_fee_or_rebate
             )
         else:
-            side = Side.Sell
+            side = Side.SELL
             price_before_fees = (
                 event.native_quantity_released - event.native_fee_or_rebate
                 if event.event_flags.maker
@@ -259,7 +259,7 @@ class Market:
         price: float, size: float, side: Side, open_orders_accounts: List[OpenOrdersAccount]
     ) -> int:
         lamports = 0
-        if side == Side.Buy:
+        if side == Side.BUY:
             lamports = round(price * size * 1.01 * LAMPORTS_PER_SOL)
             if open_orders_accounts:
                 lamports -= open_orders_accounts[0].quote_token_free
@@ -325,7 +325,7 @@ class Market:
                 order_type=order_type,
                 client_id=client_id,
                 program_id=self.state.program_id(),
-                self_trade_behavior=SelfTradeBehavior.DecrementTake,
+                self_trade_behavior=SelfTradeBehavior.DECREMENT_TAKE,
                 fee_discount_pubkey=fee_discount_pubkey,
                 limit=65535,
             )

--- a/pyserum/market/orderbook.py
+++ b/pyserum/market/orderbook.py
@@ -82,6 +82,6 @@ class OrderBook:
                     size=self._market_state.base_size_lots_to_number(node.quantity),
                     size_lots=node.quantity,
                 ),
-                side=Side.Buy if self._is_bids else Side.Sell,
+                side=Side.BUY if self._is_bids else Side.SELL,
                 open_order_slot=node.owner_slot,
             )

--- a/pyserum/market/state.py
+++ b/pyserum/market/state.py
@@ -138,8 +138,8 @@ class MarketState:  # pylint: disable=too-many-public-methods
     def price_number_to_lots(self, price: float) -> int:
         return int(
             round(
-                (price * 10 ** self.quote_spl_token_multiplier() * self.base_lot_size())
-                / (10 ** self.base_spl_token_multiplier() * self.quote_lot_size())
+                (price * self.quote_spl_token_multiplier() * self.base_lot_size())
+                / (self.base_spl_token_multiplier() * self.quote_lot_size())
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pyserum",
-    version="0.3.0a1",
+    version="0.3.1a1",
     author="serum-community",
     description="""Python client library for interacting with the Project Serum DEX.""",
     include_package_data=True,

--- a/tests/integration/test_market.py
+++ b/tests/integration/test_market.py
@@ -129,8 +129,8 @@ def test_order_placement_cancellation_cycle(
     bootstrapped_market.place_order(
         payer=stubbed_quote_wallet.public_key(),
         owner=stubbed_payer,
-        side=Side.Buy,
-        order_type=OrderType.Limit,
+        side=Side.BUY,
+        order_type=OrderType.LIMIT,
         limit_price=1000,
         max_quantity=3000,
         opts=TxOpts(skip_confirmation=False),
@@ -151,8 +151,8 @@ def test_order_placement_cancellation_cycle(
     bootstrapped_market.place_order(
         payer=stubbed_base_wallet.public_key(),
         owner=stubbed_payer,
-        side=Side.Sell,
-        order_type=OrderType.Limit,
+        side=Side.SELL,
+        order_type=OrderType.LIMIT,
         limit_price=1500,
         max_quantity=3000,
         opts=TxOpts(skip_confirmation=False),

--- a/tests/test_instruction_layouts.py
+++ b/tests/test_instruction_layouts.py
@@ -91,6 +91,7 @@ def test_parse_cancel_order_by_client_id():
     args = {"client_id": 123}
     expected = bytes.fromhex("00060000007b00000000000000")  # Raw hex from serum.js
     assert (
-        INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.CANCEL_ORDER_BY_CLIENT_ID, args=args)) == expected
+        INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.CANCEL_ORDER_BY_CLIENT_ID, args=args))
+        == expected
     )
     assert_parsed_layout(InstructionType.CANCEL_ORDER_BY_CLIENT_ID, args, expected)

--- a/tests/test_instruction_layouts.py
+++ b/tests/test_instruction_layouts.py
@@ -27,8 +27,8 @@ def test_parse_initialize_market():
     expected = bytes.fromhex(
         "000000000001000000000000000200000000000000030004000000000000000500000000000000"
     )  # Raw hex from serum.js
-    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.InitializeMarket, args=args)) == expected
-    assert_parsed_layout(InstructionType.InitializeMarket, args, expected)
+    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.INITIALIZE_MARKET, args=args)) == expected
+    assert_parsed_layout(InstructionType.INITIALIZE_MARKET, args, expected)
 
 
 def test_parse_new_order():
@@ -37,36 +37,36 @@ def test_parse_new_order():
         "limit_price": 1,
         "max_quantity": 2,
         "client_id": 3,
-        "side": Side.Sell,
-        "order_type": OrderType.PostOnly,
+        "side": Side.SELL,
+        "order_type": OrderType.POST_ONLY,
     }
     expected = bytes.fromhex(
         "00010000000100000001000000000000000200000000000000020000000300000000000000"
     )  # Raw hex from serum.js
-    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.NewOrder, args=args)) == expected
-    assert_parsed_layout(InstructionType.NewOrder, args, expected)
+    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.NEW_ORDER, args=args)) == expected
+    assert_parsed_layout(InstructionType.NEW_ORDER, args, expected)
 
 
 def test_parse_match_orders():
     """Test parsing raw match orders data."""
     args = {"limit": 1}
     expected = bytes.fromhex("00020000000100")  # Raw hex from serum.js
-    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.MatchOrder, args=args)) == expected
-    assert_parsed_layout(InstructionType.MatchOrder, args, expected)
+    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.MATCH_ORDER, args=args)) == expected
+    assert_parsed_layout(InstructionType.MATCH_ORDER, args, expected)
 
 
 def test_parse_consume_events():
     """Test parsing raw consume events data."""
     args = {"limit": 1}
     expected = bytes.fromhex("00030000000100")  # Raw hex from serum.js
-    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.ConsumeEvents, args=args)) == expected
-    assert_parsed_layout(InstructionType.ConsumeEvents, args, expected)
+    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.CONSUME_EVENTS, args=args)) == expected
+    assert_parsed_layout(InstructionType.CONSUME_EVENTS, args, expected)
 
 
 def test_parse_cancel_order():
     """Test parsing raw cancel order data."""
     args = {
-        "side": Side.Buy,
+        "side": Side.BUY,
         "order_id": (1234567890).to_bytes(16, "little"),
         "open_orders_slot": 123,
         "open_orders": bytes(PublicKey(123)),
@@ -75,15 +75,15 @@ def test_parse_cancel_order():
         "000400000000000000d202964900000000000000000000000000000000"
         "0000000000000000000000000000000000000000000000000000007b7b"
     )  # Raw hex from serum.js
-    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.CancelOrder, args=args)) == expected
-    assert_parsed_layout(InstructionType.CancelOrder, args, expected)
+    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.CANCEL_ORDER, args=args)) == expected
+    assert_parsed_layout(InstructionType.CANCEL_ORDER, args, expected)
 
 
 def test_parse_settle_funds():
     """Test parsing raw settle funds data."""
     expected = bytes.fromhex("0005000000")  # Raw hex from serum.js
-    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.SettleFunds, args=None)) == expected
-    assert_parsed_layout(InstructionType.SettleFunds, None, expected)
+    assert INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.SETTLE_FUNDS, args=None)) == expected
+    assert_parsed_layout(InstructionType.SETTLE_FUNDS, None, expected)
 
 
 def test_parse_cancel_order_by_client_id():
@@ -91,6 +91,6 @@ def test_parse_cancel_order_by_client_id():
     args = {"client_id": 123}
     expected = bytes.fromhex("00060000007b00000000000000")  # Raw hex from serum.js
     assert (
-        INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.CancelOrderByClientID, args=args)) == expected
+        INSTRUCTIONS_LAYOUT.build(dict(instruction_type=InstructionType.CANCEL_ORDER_BY_CLIENT_ID, args=args)) == expected
     )
-    assert_parsed_layout(InstructionType.CancelOrderByClientID, args, expected)
+    assert_parsed_layout(InstructionType.CANCEL_ORDER_BY_CLIENT_ID, args, expected)

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -38,7 +38,7 @@ def test_new_orders():
         request_queue=PublicKey(4),
         base_vault=PublicKey(5),
         quote_vault=PublicKey(6),
-        side=Side.Buy,
+        side=Side.BUY,
         limit_price=1,
         max_quantity=1,
         order_type=OrderType.IOC,
@@ -82,7 +82,7 @@ def test_cancel_order():
         request_queue=PublicKey(1),
         owner=PublicKey(2),
         open_orders=PublicKey(3),
-        side=Side.Buy,
+        side=Side.BUY,
         order_id=1,
         open_orders_slot=1,
     )


### PR DESCRIPTION
I think the `serum-ts` code is a bit confusing, I realize I need to look at the rust code more.

Basically, the quote currency corresponds to the `max_native_pc_qty_including_fees` (the maximum amount of quote currency in terms of native token) in DEX v3 code,
and the base currency is the `max_coin_qty` (the amount of base currency in terms of lot size, i.e. the DEX will multiple it by the base lot size).

The lot size for the DEX is basically the minimum size of the token in DEX, i.e. the smallest incremental for each token. For example, USDC has 6 decimal places, however, the lot size is 10, which means the minimum price incremental is 10^(-6) * 10 = 10 ^(-5), i.e. 0.00001 and FIDA has 6 decimal place however the lot size is 10^5, which means the smallest incremental is 10 ^(-6) * 10 ^5 = 0.1.

Previously, the `max_quote_currency` has some issue because it is not the native size, instead, it is the lot size, now we have changed this.