### PR TITLE
Wrap SOL when payer == owner for place_order on SOL market

### DIFF
--- a/pyserum/market/core.py
+++ b/pyserum/market/core.py
@@ -145,17 +145,15 @@ class MarketCore:
         open_order_accounts: Union[List[OpenOrdersAccount], List[AsyncOpenOrdersAccount]],
         place_order_open_order_account: PublicKey,
     ) -> None:
-        # unwrapped SOL cannot be used for payment
-        if payer == owner.public_key:
-            raise ValueError("Invalid payer account. Cannot use unwrapped SOL.")
-
         # TODO: add integration test for SOL wrapping.
         should_wrap_sol = (side == Side.BUY and self.state.quote_mint() == WRAPPED_SOL_MINT) or (
             side == Side.SELL and self.state.base_mint() == WRAPPED_SOL_MINT
         )
+        # Wrap SOL if payer == raw sol account
+        if payer == owner.public_key and not should_wrap_sol:
+            raise ValueError("Invalid payer account. Payer token account must hold mint tokens associated with market.")
 
         if should_wrap_sol:
-            # wrapped_sol_account = Account()
             wrapped_sol_account = Keypair()
             payer = wrapped_sol_account.public_key
             signers.append(wrapped_sol_account)


### PR DESCRIPTION
I propose the logic for place_order on SOL markets should transparently do the Create/Close wrapped SOL token mint transactions when owner==payer on a SOL market.  At the moment the logic doesn't have a clear path for what to specify for "payer" when paying for an order with SOL. The SOL wrapping is transparent to the end user since the transaction closes the wrapped sol account.

If this is acceptable, please let me know how you'd like to orchestrate a test market that has the WRAPPED_SOL_MINT as either base/quote for the tests, and I'll add it.