### PR TITLE
signers needs to be passed instead of owner

### DIFF
--- a/pyserum/market/market.py
+++ b/pyserum/market/market.py
@@ -166,4 +166,4 @@ class Market(MarketCore):
             min_bal_for_rent_exemption=min_bal_for_rent_exemption,
             should_wrap_sol=should_wrap_sol,
         )
-        return self._conn.send_transaction(transaction, owner, opts=opts)
+        return self._conn.send_transaction(transaction, *signers, opts=opts)


### PR DESCRIPTION
In the case that wrapped SOL account is created, the keypair for the new account was not being passed to send transaction resulting in an error when using the settle funds method.

This change is already present in the settle_funds implementation in the async market.