### PR TITLE
added support for init and close open_orders_accounts instructions

### DIFF
--- a/pyserum/_layouts/instructions.py
+++ b/pyserum/_layouts/instructions.py
@@ -1,9 +1,9 @@
 """Layouts for dex instructions data."""
 from enum import IntEnum
 
-from construct import Switch
 from construct import Bytes, Const, Int8ul, Int16ul, Int32ul, Int64ul, Pass
 from construct import Struct as cStruct
+from construct import Switch
 
 from .slab import KEY
 
@@ -19,6 +19,8 @@ class InstructionType(IntEnum):
     NEW_ORDER_V3 = 10
     CANCEL_ORDER_V2 = 11
     CANCEL_ORDER_BY_CLIENT_ID_V2 = 12
+    CLOSE_OPEN_ORDERS = 14
+    INIT_OPEN_ORDERS = 15
 
 
 _VERSION = 0
@@ -70,6 +72,9 @@ _CANCEL_ORDER_V2 = cStruct(
 
 _CANCEL_ORDER_BY_CLIENTID_V2 = cStruct("client_id" / Int64ul)
 
+_CLOSE_OPEN_ORDERS = cStruct()
+_INIT_OPEN_ORDERS = cStruct()
+
 INSTRUCTIONS_LAYOUT = cStruct(
     "version" / Const(_VERSION, Int8ul),
     "instruction_type" / Int32ul,
@@ -87,6 +92,8 @@ INSTRUCTIONS_LAYOUT = cStruct(
             InstructionType.NEW_ORDER_V3: _NEW_ORDER_V3,
             InstructionType.CANCEL_ORDER_V2: _CANCEL_ORDER_V2,
             InstructionType.CANCEL_ORDER_BY_CLIENT_ID_V2: _CANCEL_ORDER_BY_CLIENTID_V2,
+            InstructionType.CLOSE_OPEN_ORDERS: _CLOSE_OPEN_ORDERS,
+            InstructionType.INIT_OPEN_ORDERS: _INIT_OPEN_ORDERS,
         },
     ),
 )

--- a/pyserum/_layouts/open_orders.py
+++ b/pyserum/_layouts/open_orders.py
@@ -1,4 +1,5 @@
-from construct import Bytes, Int64ul, Padding, Struct as cStruct
+from construct import Bytes, Int64ul, Padding
+from construct import Struct as cStruct
 
 from .account_flags import ACCOUNT_FLAGS_LAYOUT
 

--- a/pyserum/_layouts/queue.py
+++ b/pyserum/_layouts/queue.py
@@ -1,4 +1,4 @@
-from construct import BitStruct, BitsInteger, BitsSwapped, Bytes, Const, Flag, Int8ul, Int32ul, Int64ul, Padding
+from construct import BitsInteger, BitsSwapped, BitStruct, Bytes, Const, Flag, Int8ul, Int32ul, Int64ul, Padding
 from construct import Struct as cStruct
 
 from .account_flags import ACCOUNT_FLAGS_LAYOUT

--- a/pyserum/_layouts/slab.py
+++ b/pyserum/_layouts/slab.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 from enum import IntEnum
 
-from construct import Switch, Bytes, Int8ul, Int32ul, Int64ul, Padding
+from construct import Bytes, Int8ul, Int32ul, Int64ul, Padding
 from construct import Struct as cStruct
+from construct import Switch
 
 from .account_flags import ACCOUNT_FLAGS_LAYOUT
 

--- a/pyserum/async_connection.py
+++ b/pyserum/async_connection.py
@@ -1,9 +1,10 @@
 from typing import List
+
 import httpx
 from solana.rpc.async_api import AsyncClient as async_conn  # pylint: disable=unused-import # noqa:F401
 
-from .market.types import MarketInfo, TokenInfo
 from .connection import LIVE_MARKETS_URL, TOKEN_MINTS_URL, parse_live_markets, parse_token_mints
+from .market.types import MarketInfo, TokenInfo
 
 
 async def get_live_markets(httpx_client: httpx.AsyncClient) -> List[MarketInfo]:

--- a/pyserum/async_open_orders_account.py
+++ b/pyserum/async_open_orders_account.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from typing import List
-from solana.rpc.async_api import AsyncClient
+
 from solana.publickey import PublicKey
-from solana.rpc.types import Commitment
+from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Recent
+from solana.rpc.types import Commitment
 
 from .async_utils import load_bytes_data
 from .open_orders_account import _OpenOrdersAccountCore

--- a/pyserum/connection.py
+++ b/pyserum/connection.py
@@ -1,9 +1,9 @@
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 import requests
-
-from solana.rpc.api import Client as conn  # pylint: disable=unused-import # noqa:F401
 from solana.publickey import PublicKey
+from solana.rpc.api import Client as conn  # pylint: disable=unused-import # noqa:F401
+
 from .market.types import MarketInfo, TokenInfo
 
 LIVE_MARKETS_URL = "https://raw.githubusercontent.com/project-serum/serum-ts/master/packages/serum/src/markets.json"

--- a/pyserum/instructions.py
+++ b/pyserum/instructions.py
@@ -484,7 +484,6 @@ def decode_cancel_order_by_client_id_v2(instruction: TransactionInstruction) -> 
 def decode_close_open_orders(
     instruction: TransactionInstruction,
 ) -> CloseOpenOrdersParams:
-    data = __parse_and_validate_instruction(instruction, InstructionType.CLOSE_OPEN_ORDERS)
     return CloseOpenOrdersParams(
         open_orders=instruction.keys[0].pubkey,
         owner=instruction.keys[1].pubkey,
@@ -496,8 +495,6 @@ def decode_close_open_orders(
 def decode_init_open_orders(
     instruction: TransactionInstruction,
 ) -> InitOpenOrdersParams:
-    data = __parse_and_validate_instruction(instruction, InstructionType.INIT_OPEN_ORDERS)
-
     market_authority = instruction.keys[3].pubkey if len(instruction.keys) == 4 else None
     return InitOpenOrdersParams(
         open_orders=instruction.keys[0].pubkey,

--- a/pyserum/market/__init__.py
+++ b/pyserum/market/__init__.py
@@ -1,4 +1,4 @@
-from .market import Market  # noqa: F401
 from .async_market import AsyncMarket  # noqa: F401
+from .market import Market  # noqa: F401
 from .orderbook import OrderBook  # noqa: F401
 from .state import MarketState as State  # noqa: F401

--- a/pyserum/market/async_market.py
+++ b/pyserum/market/async_market.py
@@ -9,17 +9,17 @@ from solana.rpc.async_api import AsyncClient
 from solana.rpc.types import RPCResponse, TxOpts
 from solana.transaction import Transaction
 
-from pyserum import instructions
 import pyserum.market.types as t
+from pyserum import instructions
 
 from .._layouts.open_orders import OPEN_ORDERS_LAYOUT
-from ..enums import OrderType, Side
 from ..async_open_orders_account import AsyncOpenOrdersAccount
 from ..async_utils import load_bytes_data
+from ..enums import OrderType, Side
 from ._internal.queue import decode_event_queue, decode_request_queue
+from .core import MarketCore
 from .orderbook import OrderBook
 from .state import MarketState
-from .core import MarketCore
 
 LAMPORTS_PER_SOL = 1000000000
 

--- a/pyserum/market/core.py
+++ b/pyserum/market/core.py
@@ -11,15 +11,14 @@ from solana.rpc.types import RPCResponse
 from solana.system_program import CreateAccountParams, create_account
 from solana.transaction import Transaction, TransactionInstruction
 from spl.token.constants import ACCOUNT_LEN, TOKEN_PROGRAM_ID, WRAPPED_SOL_MINT
-from spl.token.instructions import CloseAccountParams
-from spl.token.instructions import InitializeAccountParams, close_account, initialize_account
+from spl.token.instructions import CloseAccountParams, InitializeAccountParams, close_account, initialize_account
 
-from pyserum import instructions
 import pyserum.market.types as t
+from pyserum import instructions
 
+from ..async_open_orders_account import AsyncOpenOrdersAccount
 from ..enums import OrderType, SelfTradeBehavior, Side
 from ..open_orders_account import OpenOrdersAccount, make_create_account_instruction
-from ..async_open_orders_account import AsyncOpenOrdersAccount
 from ._internal.queue import decode_event_queue
 from .orderbook import OrderBook
 from .state import MarketState

--- a/pyserum/market/market.py
+++ b/pyserum/market/market.py
@@ -9,17 +9,17 @@ from solana.rpc.api import Client
 from solana.rpc.types import RPCResponse, TxOpts
 from solana.transaction import Transaction
 
-from pyserum import instructions
 import pyserum.market.types as t
+from pyserum import instructions
 
 from .._layouts.open_orders import OPEN_ORDERS_LAYOUT
 from ..enums import OrderType, Side
 from ..open_orders_account import OpenOrdersAccount
 from ..utils import load_bytes_data
 from ._internal.queue import decode_event_queue, decode_request_queue
+from .core import MarketCore
 from .orderbook import OrderBook
 from .state import MarketState
-from .core import MarketCore
 
 LAMPORTS_PER_SOL = 1000000000
 

--- a/pyserum/market/state.py
+++ b/pyserum/market/state.py
@@ -7,7 +7,7 @@ from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.async_api import AsyncClient
 
-from pyserum import utils, async_utils
+from pyserum import async_utils, utils
 
 from .._layouts.market import MARKET_LAYOUT
 from .types import AccountFlags

--- a/pyserum/open_orders_account.py
+++ b/pyserum/open_orders_account.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import List, NamedTuple, TypeVar, Type, Tuple
+from typing import List, NamedTuple, Tuple, Type, TypeVar
 
 from solana.publickey import PublicKey
 from solana.rpc.api import Client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-from typing import Dict
 import asyncio
+from typing import Dict
 
 import pytest
 from solana.keypair import Keypair
@@ -7,8 +7,8 @@ from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.async_api import AsyncClient
 
-from pyserum.connection import conn
 from pyserum.async_connection import async_conn
+from pyserum.connection import conn
 
 
 @pytest.mark.integration

--- a/tests/integration/test_async_connection.py
+++ b/tests/integration/test_async_connection.py
@@ -1,6 +1,6 @@
 # pylint: disable=R0801
-import pytest
 import httpx
+import pytest
 
 from pyserum.async_connection import get_live_markets, get_token_mints
 from pyserum.market.types import MarketInfo, TokenInfo

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -113,3 +113,36 @@ def test_settle_funds():
     )
     instruction = inlib.settle_funds(params)
     assert inlib.decode_settle_funds(instruction) == params
+
+
+def test_close_open_orders():
+    """Test settle funds."""
+    params = inlib.CloseOpenOrdersParams(
+        open_orders=PublicKey(0),
+        owner=PublicKey(1),
+        sol_wallet=PublicKey(2),
+        market=PublicKey(3),
+    )
+    instruction = inlib.close_open_orders(params)
+    assert inlib.decode_close_open_orders(instruction) == params
+
+
+def test_init_open_orders():
+    """Test settle funds."""
+    params = inlib.InitOpenOrdersParams(
+        open_orders=PublicKey(0), owner=PublicKey(1), market=PublicKey(2), market_authority=None
+    )
+    instruction = inlib.init_open_orders(params)
+    assert inlib.decode_init_open_orders(instruction) == params
+
+
+def test_init_open_orders_with_authority():
+    """Test settle funds."""
+    params = inlib.InitOpenOrdersParams(
+        open_orders=PublicKey(0),
+        owner=PublicKey(1),
+        market=PublicKey(2),
+        market_authority=PublicKey(3),
+    )
+    instruction = inlib.init_open_orders(params)
+    assert inlib.decode_init_open_orders(instruction) == params


### PR DESCRIPTION
Added support for the additional open_orders instructions based on discussion in the Serum Core TG channel.

I've added some unittests and ran `make format` before pushing which seems to have resulted in some unrelated formatting changes. Perhaps `make format` needs running on `alpha`?

I **haven't** modified the logic [here](https://github.com/serum-community/pyserum/blob/6f3ba279da70c828b54a09b76741137ebf41b075/pyserum/market/core.py#L117) to always add an init_open_orders instruction immediately after. This could either be added as part of this PR or a subsequent one?

Prevents this type of attack https://twitter.com/Henry_E__/status/1461821861701074946?s=20

AD